### PR TITLE
utils.c: Include stdlib.h to avoid gcc warnings

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 
 void strncpy_pad(char *dest, const char *src, size_t n) {
   size_t len = strlen(src);


### PR DESCRIPTION
GCC is complaining about implicit declaration of function 'malloc'. Add "#include <stdlib.h>" to avoid it.
```
src/utils.c: In function ‘read_file’:
src/utils.c:58:12: warning: implicit declaration of function ‘malloc’ [-Wimplicit-function-declaration]
   buffer = malloc(*length + pre_length);
            ^~~~~~
src/utils.c:58:12: warning: incompatible implicit declaration of built-in function ‘malloc’
src/utils.c:58:12: note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’
```