### PR TITLE
Support for tpm2-tss 2.0.0

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -99,8 +99,8 @@ pObjectList object_load(TSS2_SYS_CONTEXT *ctx, struct config *config) {
     goto error;
   
   TPMS_CAPABILITY_DATA persistent;
-  TPM_RC rc = tpm_list(ctx, &persistent);
-  if (rc != TPM_RC_SUCCESS)
+  TPM2_RC rc = tpm_list(ctx, &persistent);
+  if (rc != TPM2_RC_SUCCESS)
     goto error;
 
   for (int i = 0; i < persistent.data.handles.count; i++) {
@@ -111,7 +111,7 @@ pObjectList object_load(TSS2_SYS_CONTEXT *ctx, struct config *config) {
     memset(userdata, 0, sizeof(UserdataTpm));
     userdata->name.t.size = sizeof(TPMU_NAME);
     rc = tpm_readpublic(ctx, persistent.data.handles.handle[i], &userdata->tpm_key, &userdata->name);
-    if (rc != TPM_RC_SUCCESS) {
+    if (rc != TPM2_RC_SUCCESS) {
       free(userdata);
       goto error;
     }

--- a/src/objects.c
+++ b/src/objects.c
@@ -138,7 +138,7 @@ pObjectList object_load(TSS2_SYS_CONTEXT *ctx, struct config *config) {
       goto error;
     }
 
-    object->tpm_handle = NULL;
+    object->tpm_handle = 0;
     object->userdata = userdata;
     object->num_entries = 3;
     object->entries = calloc(object->num_entries, sizeof(AttrIndexEntry));

--- a/src/objects.c
+++ b/src/objects.c
@@ -109,25 +109,25 @@ pObjectList object_load(TSS2_SYS_CONTEXT *ctx, struct config *config) {
       goto error;
 
     memset(userdata, 0, sizeof(UserdataTpm));
-    userdata->name.t.size = sizeof(TPMU_NAME);
+    userdata->name.size = sizeof(TPMU_NAME);
     rc = tpm_readpublic(ctx, persistent.data.handles.handle[i], &userdata->tpm_key, &userdata->name);
     if (rc != TPM2_RC_SUCCESS) {
       free(userdata);
       goto error;
     }
-    TPM2B_PUBLIC_KEY_RSA *rsa_key = &userdata->tpm_key.t.publicArea.unique.rsa;
-    TPMS_RSA_PARMS *rsa_key_parms = &userdata->tpm_key.t.publicArea.parameters.rsaDetail;
+    TPM2B_PUBLIC_KEY_RSA *rsa_key = &userdata->tpm_key.publicArea.unique.rsa;
+    TPMS_RSA_PARMS *rsa_key_parms = &userdata->tpm_key.publicArea.parameters.rsaDetail;
 
-    userdata->public_object.id = userdata->name.t.name;
-    userdata->public_object.id_size = userdata->name.t.size;
+    userdata->public_object.id = userdata->name.name;
+    userdata->public_object.id_size = userdata->name.size;
     userdata->public_object.class = CKO_PUBLIC_KEY;
-    userdata->private_object.id = userdata->name.t.name;
-    userdata->private_object.id_size = userdata->name.t.size;
+    userdata->private_object.id = userdata->name.name;
+    userdata->private_object.id_size = userdata->name.size;
     userdata->private_object.class = CKO_PRIVATE_KEY;
     userdata->key.sign = CK_TRUE;
     userdata->key.decrypt = CK_TRUE;
     userdata->key.key_type = CKK_RSA;
-    userdata->public_key.modulus = rsa_key->b.buffer;
+    userdata->public_key.modulus = rsa_key->buffer;
     userdata->public_key.modulus_size = rsa_key_parms->keyBits / 8;
     userdata->public_key.bits = rsa_key_parms->keyBits;
     userdata->public_key.exponent = htobe32(rsa_key_parms->exponent == 0 ? 65537 : rsa_key_parms->exponent);

--- a/src/pk11.c
+++ b/src/pk11.c
@@ -192,15 +192,15 @@ CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG usDataLen, 
   TPM2_RC ret;
 
   if (pk11_config.sign_using_encrypt) {
-    TPM2B_PUBLIC_KEY_RSA message = { .t.size = TPM2_MAX_RSA_KEY_BYTES };
+    TPM2B_PUBLIC_KEY_RSA message = { .size = TPM2_MAX_RSA_KEY_BYTES };
     pObject object = session->current_object->opposite;
     CK_ULONG_PTR key_size = (CK_ULONG_PTR) attr_get(object, CKA_MODULUS_BITS, NULL);
     ret = tpm_sign_encrypt(session->context, session->keyHandle, *key_size / 8, pData, usDataLen, &message);
-    retmem(pSignature, pusSignatureLen, message.t.buffer, message.t.size);
+    retmem(pSignature, pusSignatureLen, message.buffer, message.size);
   } else {
     TPMT_SIGNATURE signature = {0};
     ret = tpm_sign(session->context, session->keyHandle, pData, usDataLen, &signature);
-    retmem(pSignature, pusSignatureLen, signature.signature.rsassa.sig.t.buffer, signature.signature.rsassa.sig.t.size);
+    retmem(pSignature, pusSignatureLen, signature.signature.rsassa.sig.buffer, signature.signature.rsassa.sig.size);
   }
 
   return ret == TPM2_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
@@ -213,10 +213,10 @@ CK_RV C_DecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_
 }
 
 CK_RV C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen, CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen) {
-  TPM2B_PUBLIC_KEY_RSA message = { .t.size = TPM2_MAX_RSA_KEY_BYTES };
+  TPM2B_PUBLIC_KEY_RSA message = { .size = TPM2_MAX_RSA_KEY_BYTES };
   struct session* session = get_session(hSession);
   TPM2_RC ret = tpm_decrypt(session->context, session->keyHandle, pEncryptedData, ulEncryptedDataLen, &message);
-  retmem(pData, pulDataLen, message.t.buffer, message.t.size);
+  retmem(pData, pulDataLen, message.buffer, message.size);
 
   return ret == TPM2_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
 }

--- a/src/pk11.c
+++ b/src/pk11.c
@@ -189,10 +189,10 @@ CK_RV C_SignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJ
 
 CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG usDataLen, CK_BYTE_PTR pSignature, CK_ULONG_PTR pusSignatureLen) {
   struct session* session = get_session(hSession);
-  TPM_RC ret;
+  TPM2_RC ret;
 
   if (pk11_config.sign_using_encrypt) {
-    TPM2B_PUBLIC_KEY_RSA message = { .t.size = MAX_RSA_KEY_BYTES };
+    TPM2B_PUBLIC_KEY_RSA message = { .t.size = TPM2_MAX_RSA_KEY_BYTES };
     pObject object = session->current_object->opposite;
     CK_ULONG_PTR key_size = (CK_ULONG_PTR) attr_get(object, CKA_MODULUS_BITS, NULL);
     ret = tpm_sign_encrypt(session->context, session->keyHandle, *key_size / 8, pData, usDataLen, &message);
@@ -203,7 +203,7 @@ CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG usDataLen, 
     retmem(pSignature, pusSignatureLen, signature.signature.rsassa.sig.t.buffer, signature.signature.rsassa.sig.t.size);
   }
 
-  return ret == TPM_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
+  return ret == TPM2_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
 }
 
 CK_RV C_DecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey) {
@@ -213,12 +213,12 @@ CK_RV C_DecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_
 }
 
 CK_RV C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen, CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen) {
-  TPM2B_PUBLIC_KEY_RSA message = { .t.size = MAX_RSA_KEY_BYTES };
+  TPM2B_PUBLIC_KEY_RSA message = { .t.size = TPM2_MAX_RSA_KEY_BYTES };
   struct session* session = get_session(hSession);
-  TPM_RC ret = tpm_decrypt(session->context, session->keyHandle, pEncryptedData, ulEncryptedDataLen, &message);
+  TPM2_RC ret = tpm_decrypt(session->context, session->keyHandle, pEncryptedData, ulEncryptedDataLen, &message);
   retmem(pData, pulDataLen, message.t.buffer, message.t.size);
 
-  return ret == TPM_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
+  return ret == TPM2_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
 }
 
 CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -25,12 +25,9 @@ const unsigned char oid_sha1[] = {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E
 const unsigned char oid_sha256[] = {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20};
 
 TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name) {
-  TPMS_AUTH_RESPONSE sessionDataOut;
-  TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = {&sessionDataOut};
-
-  TSS2_SYS_RSP_AUTHS sessionsDataOut;
-  sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-  sessionsDataOut.rspAuthsCount = 1;
+  TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {
+    .count = 1,
+  };
 
   TPM2B_NAME qualifiedName = { .size = sizeof(TPMU_NAME) };
 
@@ -38,20 +35,16 @@ TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_P
 }
 
 TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *hash, unsigned long hashLength, TPMT_SIGNATURE *signature) {
-  TPMS_AUTH_COMMAND sessionData = {0};
-  sessionData.sessionHandle = TPM_RS_PW;
+  TSS2L_SYS_AUTH_COMMAND sessionsData = {
+	  .count = 1,
+	  .auths[0] = {
+		  .sessionHandle = TPM2_RS_PW,
+	  },
+  };
 
-  TPMS_AUTH_RESPONSE sessionDataOut;
-  TPMS_AUTH_COMMAND *sessionDataArray[1] = {&sessionData};
-  TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = {&sessionDataOut};
-
-  TSS2_SYS_CMD_AUTHS sessionsData;
-  sessionsData.cmdAuths = &sessionDataArray[0];
-  sessionsData.cmdAuthsCount = 1;
-
-  TSS2_SYS_RSP_AUTHS sessionsDataOut;
-  sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-  sessionsDataOut.rspAuthsCount = 1;
+  TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {
+    .count = 1,
+  };
 
   TPMT_TK_HASHCHECK validation = {0};
   validation.tag = TPM2_ST_HASHCHECK;
@@ -78,20 +71,16 @@ TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char
 }
 
 TPM2_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *cipherText, unsigned long cipherLength, TPM2B_PUBLIC_KEY_RSA *message) {
-  TPMS_AUTH_COMMAND sessionData = {0};
-  sessionData.sessionHandle = TPM_RS_PW;
+  TSS2L_SYS_AUTH_COMMAND sessionsData = {
+	  .count = 1,
+	  .auths[0] = {
+		  .sessionHandle = TPM2_RS_PW,
+	  },
+  };
 
-  TPMS_AUTH_RESPONSE sessionDataOut;
-  TPMS_AUTH_COMMAND *sessionDataArray[1] = {&sessionData};
-  TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = {&sessionDataOut};
-
-  TSS2_SYS_CMD_AUTHS sessionsData;
-  sessionsData.cmdAuths = &sessionDataArray[0];
-  sessionsData.cmdAuthsCount = 1;
-
-  TSS2_SYS_RSP_AUTHS sessionsDataOut;
-  sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-  sessionsDataOut.rspAuthsCount = 1;
+  TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = {
+	  .count = 1,
+  };
 
   TPM2B_DATA label = {0};
 
@@ -105,13 +94,12 @@ TPM2_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned c
 }
 
 TPM2_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t key_size, unsigned char *hash, size_t hash_length, TPM2B_PUBLIC_KEY_RSA *signature) {
-  TPMS_AUTH_COMMAND sessionData = {0};
-  sessionData.sessionHandle = TPM_RS_PW;
-
-  TPMS_AUTH_COMMAND *sessionDataArray[1] = {&sessionData};
-  TSS2_SYS_CMD_AUTHS sessionsData;
-  sessionsData.cmdAuths = &sessionDataArray[0];
-  sessionsData.cmdAuthsCount = 1;
+  TSS2L_SYS_AUTH_COMMAND sessionsData = {
+	  .count = 1,
+	  .auths[0] = {
+		  .sessionHandle = TPM2_RS_PW,
+	  },
+  };
 
   TPM2B_PUBLIC_KEY_RSA message = { .size = key_size };
   unsigned char *p = message.buffer;

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -24,7 +24,7 @@
 const unsigned char oid_sha1[] = {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E, 0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14};
 const unsigned char oid_sha256[] = {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20};
 
-TPM_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name) {
+TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name) {
   TPMS_AUTH_RESPONSE sessionDataOut;
   TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = {&sessionDataOut};
 
@@ -37,7 +37,7 @@ TPM_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PU
   return Tss2_Sys_ReadPublic(context, handle, 0, public, name, &qualifiedName, &sessionsDataOut);
 }
 
-TPM_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *hash, unsigned long hashLength, TPMT_SIGNATURE *signature) {
+TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *hash, unsigned long hashLength, TPMT_SIGNATURE *signature) {
   TPMS_AUTH_COMMAND sessionData = {0};
   sessionData.sessionHandle = TPM_RS_PW;
 
@@ -54,21 +54,21 @@ TPM_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char 
   sessionsDataOut.rspAuthsCount = 1;
 
   TPMT_TK_HASHCHECK validation = {0};
-  validation.tag = TPM_ST_HASHCHECK;
-  validation.hierarchy = TPM_RH_NULL;
+  validation.tag = TPM2_ST_HASHCHECK;
+  validation.hierarchy = TPM2_RH_NULL;
 
   TPMT_SIG_SCHEME scheme;
-  scheme.scheme = TPM_ALG_RSASSA;
+  scheme.scheme = TPM2_ALG_RSASSA;
 
   int digestSize;
   if (memcmp(hash, oid_sha1, sizeof(oid_sha1)) == 0) {
-    scheme.details.rsassa.hashAlg = TPM_ALG_SHA1;
-    digestSize = SHA1_DIGEST_SIZE;
+    scheme.details.rsassa.hashAlg = TPM2_ALG_SHA1;
+    digestSize = TPM2_SHA1_DIGEST_SIZE;
   } else if (memcmp(hash, oid_sha256, sizeof(oid_sha256)) == 0) {
-    scheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
-    digestSize = SHA256_DIGEST_SIZE;
+    scheme.details.rsassa.hashAlg = TPM2_ALG_SHA256;
+    digestSize = TPM2_SHA256_DIGEST_SIZE;
   } else
-    return TPM_RC_FAILURE;
+    return TPM2_RC_FAILURE;
 
   TPM2B_DIGEST digest = { .t.size = digestSize };
   // Remove OID from hash if provided
@@ -77,7 +77,7 @@ TPM_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char 
   return Tss2_Sys_Sign(context, handle, &sessionsData, &digest, &scheme, &validation, signature, &sessionsDataOut);
 }
 
-TPM_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *cipherText, unsigned long cipherLength, TPM2B_PUBLIC_KEY_RSA *message) {
+TPM2_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *cipherText, unsigned long cipherLength, TPM2B_PUBLIC_KEY_RSA *message) {
   TPMS_AUTH_COMMAND sessionData = {0};
   sessionData.sessionHandle = TPM_RS_PW;
 
@@ -88,7 +88,7 @@ TPM_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned ch
   TSS2_SYS_CMD_AUTHS sessionsData;
   sessionsData.cmdAuths = &sessionDataArray[0];
   sessionsData.cmdAuthsCount = 1;
-  
+
   TSS2_SYS_RSP_AUTHS sessionsDataOut;
   sessionsDataOut.rspAuths = &sessionDataOutArray[0];
   sessionsDataOut.rspAuthsCount = 1;
@@ -96,7 +96,7 @@ TPM_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned ch
   TPM2B_DATA label = {0};
 
   TPMT_RSA_DECRYPT scheme;
-  scheme.scheme = TPM_ALG_RSAES;
+  scheme.scheme = TPM2_ALG_RSAES;
 
   TPM2B_PUBLIC_KEY_RSA cipher = { .t.size = cipherLength };
   memcpy(cipher.t.buffer, cipherText, cipherLength);
@@ -104,7 +104,7 @@ TPM_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned ch
   return Tss2_Sys_RSA_Decrypt(context, handle, &sessionsData, &cipher, &scheme, &label, message, &sessionsDataOut);
 }
 
-TPM_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t key_size, unsigned char *hash, size_t hash_length, TPM2B_PUBLIC_KEY_RSA *signature) {
+TPM2_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t key_size, unsigned char *hash, size_t hash_length, TPM2B_PUBLIC_KEY_RSA *signature) {
   TPMS_AUTH_COMMAND sessionData = {0};
   sessionData.sessionHandle = TPM_RS_PW;
 
@@ -125,13 +125,13 @@ TPM_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t
   memcpy(p, hash, hash_length);
 
   TPM2B_DATA label = {0};
-  TPMT_RSA_DECRYPT scheme = { .scheme = TPM_ALG_NULL };
+  TPMT_RSA_DECRYPT scheme = { .scheme = TPM2_ALG_NULL };
 
   return Tss2_Sys_RSA_Decrypt(context, handle, &sessionsData, &message, &scheme, &label, signature, NULL);
 }
 
-TPM_RC tpm_list(TSS2_SYS_CONTEXT *context, TPMS_CAPABILITY_DATA* capabilityData) {
+TPM2_RC tpm_list(TSS2_SYS_CONTEXT *context, TPMS_CAPABILITY_DATA* capabilityData) {
   TPMI_YES_NO moreData;
 
-  return Tss2_Sys_GetCapability(context, 0, TPM_CAP_HANDLES, htobe32(TPM_HT_PERSISTENT), TPM_PT_HR_PERSISTENT, &moreData, capabilityData, 0);
+  return Tss2_Sys_GetCapability(context, 0, TPM2_CAP_HANDLES, htobe32(TPM2_HT_PERSISTENT), TPM2_PT_TPM2_HR_PERSISTENT, &moreData, capabilityData, 0);
 }

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -32,7 +32,7 @@ TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_P
   sessionsDataOut.rspAuths = &sessionDataOutArray[0];
   sessionsDataOut.rspAuthsCount = 1;
 
-  TPM2B_NAME qualifiedName = { .t.size = sizeof(TPMU_NAME) };
+  TPM2B_NAME qualifiedName = { .size = sizeof(TPMU_NAME) };
 
   return Tss2_Sys_ReadPublic(context, handle, 0, public, name, &qualifiedName, &sessionsDataOut);
 }
@@ -70,9 +70,9 @@ TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char
   } else
     return TPM2_RC_FAILURE;
 
-  TPM2B_DIGEST digest = { .t.size = digestSize };
+  TPM2B_DIGEST digest = { .size = digestSize };
   // Remove OID from hash if provided
-  memcpy(digest.t.buffer, hash - digestSize + hashLength, hashLength);
+  memcpy(digest.buffer, hash - digestSize + hashLength, hashLength);
 
   return Tss2_Sys_Sign(context, handle, &sessionsData, &digest, &scheme, &validation, signature, &sessionsDataOut);
 }
@@ -98,8 +98,8 @@ TPM2_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned c
   TPMT_RSA_DECRYPT scheme;
   scheme.scheme = TPM2_ALG_RSAES;
 
-  TPM2B_PUBLIC_KEY_RSA cipher = { .t.size = cipherLength };
-  memcpy(cipher.t.buffer, cipherText, cipherLength);
+  TPM2B_PUBLIC_KEY_RSA cipher = { .size = cipherLength };
+  memcpy(cipher.buffer, cipherText, cipherLength);
 
   return Tss2_Sys_RSA_Decrypt(context, handle, &sessionsData, &cipher, &scheme, &label, message, &sessionsDataOut);
 }
@@ -113,8 +113,8 @@ TPM2_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_
   sessionsData.cmdAuths = &sessionDataArray[0];
   sessionsData.cmdAuthsCount = 1;
 
-  TPM2B_PUBLIC_KEY_RSA message = { .t.size = key_size };
-  unsigned char *p = message.t.buffer;
+  TPM2B_PUBLIC_KEY_RSA message = { .size = key_size };
+  unsigned char *p = message.buffer;
 
   *p++ = 0;
   *p++ = 1;

--- a/src/tpm.h
+++ b/src/tpm.h
@@ -19,8 +19,8 @@
 
 #include <sapi/tpm20.h>
 
-TPM_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name);
-TPM_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *hash, unsigned long hashLength, TPMT_SIGNATURE *signature);
-TPM_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *cipherText, unsigned long cipherLength, TPM2B_PUBLIC_KEY_RSA *message);
-TPM_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t key_size, unsigned char *message, size_t message_length, TPM2B_PUBLIC_KEY_RSA *signature);
-TPM_RC tpm_list(TSS2_SYS_CONTEXT *context, TPMS_CAPABILITY_DATA* capabilityData);
+TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name);
+TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *hash, unsigned long hashLength, TPMT_SIGNATURE *signature);
+TPM2_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *cipherText, unsigned long cipherLength, TPM2B_PUBLIC_KEY_RSA *message);
+TPM2_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t key_size, unsigned char *message, size_t message_length, TPM2B_PUBLIC_KEY_RSA *signature);
+TPM2_RC tpm_list(TSS2_SYS_CONTEXT *context, TPMS_CAPABILITY_DATA* capabilityData);

--- a/src/utils.c
+++ b/src/utils.c
@@ -57,7 +57,7 @@ void* read_file(const char* filename, size_t* length) {
   size_t pre_length = *length;
   *length = s.st_size;
   buffer = malloc(*length + pre_length);
-  printf("Is %d, %x, %x\n", pre_length, buffer, buffer + pre_length);
+  printf("Is %lu, %p, %p\n", pre_length, buffer, buffer + pre_length);
   if (buffer == NULL || read(fd, buffer + pre_length, *length) != *length)
     *length = 0;
 


### PR DESCRIPTION
This pull request allow tpm2-pk11 to be built with the latest versions of tpm2-tss (v2.0.0 and git version) and fixes a few unimportant warnings as well. 

The most important changes are: 

- most TPM_ constants has been moved to the TPM2_ namespace
- the TPMB structures has been simplified (no more .t.)
- the AUTH/RESP structures has been simplified as well (they now include an array instead of a pointer to an array). 

Best regards, 

-- Emmanuel Deloget