### PR TITLE
Fix PATH_MAX undeclared issue on hurd-i386 platform

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -27,6 +27,9 @@
 #include <stdio.h>
 #include <endian.h>
 #include <limits.h>
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 #include <glob.h>
 
 typedef struct userdata_tpm_t {


### PR DESCRIPTION
MAX_PATH is not defined in some platforms, most notably GNU/Hurd. Therefore, I define the value of MAX_PATH here to 4096 which is the same value in limits.h.