### PR TITLE
Get certificates from the TPM2 NVRAM

### DIFF
--- a/src/certificate.h
+++ b/src/certificate.h
@@ -20,5 +20,7 @@
 #pragma once
 
 #include "object.h"
+#include "tpm.h"
 
 pObject certificate_read(const char* pathname);
+pObject certificate_read_from_tpm(TSS2_SYS_CONTEXT *context, TPMI_RH_NV_INDEX index);

--- a/src/objects.c
+++ b/src/objects.c
@@ -100,7 +100,7 @@ pObjectList object_load(TSS2_SYS_CONTEXT *ctx, struct config *config) {
 
   if (list == NULL)
     goto error;
-  
+
   TPMS_CAPABILITY_DATA persistent;
   TPM2_RC rc = tpm_list(ctx, &persistent);
   if (rc != TPM2_RC_SUCCESS)
@@ -165,6 +165,17 @@ pObjectList object_load(TSS2_SYS_CONTEXT *ctx, struct config *config) {
 
     public_object->opposite = object;
     object->opposite = public_object;
+  }
+
+  TPMS_CAPABILITY_DATA nvlist;
+  rc = tpm_nvlist(ctx, &nvlist);
+  if (rc != TPM2_RC_SUCCESS)
+    goto error;
+
+  for (int i = 0; i < nvlist.data.handles.count; i++) {
+    pObject object = certificate_read_from_tpm(ctx, nvlist.data.handles.handle[i]);
+    if (object)
+      object_add(list, object);
   }
 
   if (config->certificates) {

--- a/src/tpm.h
+++ b/src/tpm.h
@@ -24,3 +24,6 @@ TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char
 TPM2_RC tpm_decrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char *cipher_text, unsigned long cipher_length, TPM2B_PUBLIC_KEY_RSA *message);
 TPM2_RC tpm_sign_encrypt(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, size_t key_size, unsigned char *message, size_t message_length, TPM2B_PUBLIC_KEY_RSA *signature);
 TPM2_RC tpm_list(TSS2_SYS_CONTEXT *context, TPMS_CAPABILITY_DATA* capability_data);
+TPM2_RC tpm_nvlist(TSS2_SYS_CONTEXT *context, TPMS_CAPABILITY_DATA* capability_data);
+TPM2_RC tpm_nvreadpublic(TSS2_SYS_CONTEXT *context, TPMI_RH_NV_INDEX index, TPM2B_NV_PUBLIC *nvpublic);
+TPM2_RC tpm_nvread(TSS2_SYS_CONTEXT *context, TPMI_RH_NV_INDEX index, void *data, unsigned long *size);


### PR DESCRIPTION
DER Certificates can be stored in the directory specified by the certificate option in the configuration file, but they can also be stored within the TPM2 itself, in the NVRAM. That's for example the setup in strongswan (see [the strongswan documentation on Trusted Platform Module 2.0](https://wiki.strongswan.org/projects/strongswan/wiki/TPMPlugin) for further information). 

This makes the certificates resistant to a disk wipeout. 

To add a certificate in the TPM2 nvram, 

```
FILE=<path-to-the-certificate>
SIZE=$(cat $FILE | wc -c)
tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s $SIZE -t 0x2000A
tpm2_nvwrite -x 0x1500016 -a 0x40000001 $FILE
```

The code makes storing certificates in the NVRAM equivalent to storing them on the disk.

Best regards, 

-- Emmanuel Deloget