### PR TITLE
Safely remove unnecessary header guards for tcti_socket tcti_device

### DIFF
--- a/src/sessions.c
+++ b/src/sessions.c
@@ -21,12 +21,8 @@
 
 #include <stdlib.h>
 
-#ifdef TCTI_SOCKET_ENABLED
 #include <tcti/tcti_socket.h>
-#endif // TCTI_SOCKET_ENABLED
-#ifdef TCTI_DEVICE_ENABLED
 #include <tcti/tcti_device.h>
-#endif // TCTI_DEVICE_ENABLED
 #ifdef TCTI_TABRMD_ENABLED
 #include <tcti/tcti-tabrmd.h>
 #endif // TCTI_TABRMD_ENABLED


### PR DESCRIPTION
Header file "tcti/tcti_socket.h" and "tcti/tcti_device.h" are always available since they would always be shipped with other TSS headers. There's no need to keep them in a pair of "#ifdef"/"#endif" header guards.