### PR TITLE
Allow the creation of certificate request with openssl

### DIFF
--- a/src/pk11.c
+++ b/src/pk11.c
@@ -105,7 +105,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID id, CK_TOKEN_INFO_PTR info) {
   strncpy_pad(info->serialNumber, TPM2_PK11_SERIAL, sizeof(info->serialNumber));
   strncpy_pad(info->utcTime, "", sizeof(info->utcTime));
 
-  info->flags = CKF_TOKEN_INITIALIZED;
+  info->flags = CKF_TOKEN_INITIALIZED | CKF_WRITE_PROTECTED;
   info->ulMaxSessionCount = 1;
   info->ulSessionCount = 0;
   info->ulMaxRwSessionCount = 1;

--- a/src/pk11.h
+++ b/src/pk11.h
@@ -46,11 +46,14 @@ typedef struct pkcs_key_t {
 } PkcsKey, *pPkcsKey;
 
 typedef struct pkcs_public_key_t {
+  uint32_t exponent;
+} PkcsPublicKey, *pPkcsPublicKey;
+
+typedef struct pkcs_modulus_t {
   void* modulus;
   size_t modulus_size;
   CK_ULONG bits;
-  uint32_t exponent;
-} PkcsPublicKey, *pPkcsPublicKey;
+} PkcsModulus, *pPkcsModulus;
 
 typedef struct pkcs_x509_t {
   char* value;

--- a/src/pk11.h
+++ b/src/pk11.h
@@ -36,6 +36,8 @@
 typedef struct pkcs_object_t {
   void* id;
   size_t id_size;
+  char* label;
+  size_t label_size;
   CK_OBJECT_CLASS class;
 } PkcsObject, *pPkcsObject;
 

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -23,6 +23,8 @@
 
 const unsigned char oid_sha1[] = {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E, 0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14};
 const unsigned char oid_sha256[] = {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20};
+const unsigned char oid_sha384[] = {0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05,0x00, 0x04, 0x30};
+const unsigned char oid_sha512[] = {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,0x00, 0x04, 0x40};
 
 TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name) {
   TSS2L_SYS_AUTH_RESPONSE sessions_data_out = { .count = 1 };
@@ -48,12 +50,18 @@ TPM2_RC tpm_sign(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, unsigned char
   scheme.scheme = TPM2_ALG_RSASSA;
 
   int digestSize;
-  if (memcmp(hash, oid_sha1, sizeof(oid_sha1)) == 0) {
+  if (sizeof(oid_sha1) < hash_length && memcmp(hash, oid_sha1, sizeof(oid_sha1)) == 0) {
     scheme.details.rsassa.hashAlg = TPM2_ALG_SHA1;
     digestSize = TPM2_SHA1_DIGEST_SIZE;
-  } else if (memcmp(hash, oid_sha256, sizeof(oid_sha256)) == 0) {
+  } else if (sizeof(oid_sha256) < hash_length && memcmp(hash, oid_sha256, sizeof(oid_sha256)) == 0) {
     scheme.details.rsassa.hashAlg = TPM2_ALG_SHA256;
     digestSize = TPM2_SHA256_DIGEST_SIZE;
+  } else if (sizeof(oid_sha384) < hash_length && memcmp(hash, oid_sha384, sizeof(oid_sha384)) == 0) {
+    scheme.details.rsassa.hashAlg = TPM2_ALG_SHA384;
+    digestSize = TPM2_SHA384_DIGEST_SIZE;
+  } else if (sizeof(oid_sha512) < hash_length && memcmp(hash, oid_sha512, sizeof(oid_sha512)) == 0) {
+    scheme.details.rsassa.hashAlg = TPM2_ALG_SHA512;
+    digestSize = TPM2_SHA512_DIGEST_SIZE;
   } else
     return TPM2_RC_FAILURE;
 


### PR DESCRIPTION
The libp11 project proposes **pkcs11.so**, a PKCS#11 engine for openssl that can be tested with 

`openssl engine pkcs11 -t`

It's fully compatible with providers created with p11-kit, including tpm2-pk11. 

The proposed changes implement certificate request creation with openssl when using this engine. It does so in multiple steps. 

* mark the token as write protected ; without this change it's not possible to use a non-protected RSA key with no associated pincode.
* provide a CKA_MODULUS attribute to private keys ; without this, the pcs11.so engine will crash when it'll try to get the RSA private key parameters. 
* provide a CKA_LABEL attribute to both public and private keys. The CKA_LABEL is a string representation of the CKA_ID for now. It's used when browsing keys. 

With these three changes, it's possible to create a CSR file based upon a non-protected RSA private key (protected (i.e. attestation) keys require the digest to be computed on the TPM2, so that won't fly). 

`openssl req -new -engine pkcs11 -keyform e -key label_${LABEL} -config ${CONFIG}`

or, with a pkcs11 URL (RFC)

`openssl req -new -engine pkcs11 -keyform e -key 'pkcs11:id=%54%56%12%02%98%23...' -config ${CONFIG}`

This was requested in the tpm2-tools project (https://github.com/intel/tpm2-tools/issues/756) but it really belongs here and in libp11 (allowing the use of openssl to create certificate requests). 

This PR requires https://github.com/OpenSC/libp11/pull/200 to be applied on libp11 (otherwise it will crash because of a bug in lipb11). 

Another (less important) patch add support for sha384 and sha512 discovery in tpm_sign(). I had a case where I got a sha512 input to this function (so it can definitely happen). 

Best regards, 

-- Emmanuel Deloget
