### PR TITLE
attribute: add the CKA_CERTIFICATE_TYPE attribute to certificates

### DIFF
--- a/src/certificate.c
+++ b/src/certificate.c
@@ -42,6 +42,7 @@ static AttrIndex OBJECT_INDEX[] = {
 
 static AttrIndex CERTIFICATE_INDEX[] = {
   attr_dynamic_index_of(CKA_VALUE, PkcsX509, value, value_size),
+  attr_index_of(CKA_CERTIFICATE_TYPE, PkcsX509, cert_type),
 };
 
 pObject certificate_read(const char* pathname) {
@@ -69,6 +70,7 @@ pObject certificate_read(const char* pathname) {
 
   userdata->certificate.value_size = size;
   userdata->certificate.value = ((char*) userdata) + sizeof(UserdataCertificate);
+  userdata->certificate.cert_type = CKC_X_509;
 
   object->userdata = userdata;
   object->num_entries = 2;

--- a/src/pk11.h
+++ b/src/pk11.h
@@ -60,4 +60,5 @@ typedef struct pkcs_modulus_t {
 typedef struct pkcs_x509_t {
   char* value;
   size_t value_size;
+  CK_CERTIFICATE_TYPE cert_type;
 } PkcsX509, *pPkcsX509;


### PR DESCRIPTION
This attribute is required by libp11 to allow certificates to be used.
With this change, it's now possible to take advantage of tpm2-pk11 with
programs that uses certificates on any openssl/libp11 setup.

libp11 expects the following attributes on certificates:

* CKA_CLASS (ok)
* CKA_ID (ok)
* CKA_VALUE (ok)
* CKA_CERTIFICATE_TYPE (missing)

Although it's optionnal, it also try to read CKA_LABEL (this is not
handled in this patch).

This change adds the CKA_CERTIFICATE_TYPE attribute, with value
CKC_X_509.

One can then use cURL with

curl --engine pkcs11 \
	--cert-type ENG -E 'pkcs11:id=$CID' \
	--key-type ENG --key 'pkcs11:id=$KID' \
	--cacert /my/ca.pem \
	https://my.protected.url/

CID is the id of the certificate, KID is the id of the private key (i.e.
it's name).

This has been mainly tested with cURL but should work with some other
softwares.

Signed-off-by: Emmanuel Deloget <logout@free.fr>