### PR TITLE
Follow upstream API changes

### DIFF
--- a/src/sessions.c
+++ b/src/sessions.c
@@ -44,9 +44,6 @@ int session_init(struct session* session, struct config *config) {
   TCTI_SOCKET_CONF socket_conf = {
     .hostname = config->hostname != NULL ? config->hostname : DEFAULT_HOSTNAME,
     .port = config->port > 0 ? config->port : DEFAULT_PORT,
-    .logCallback = NULL,
-    .logBufferCallback = NULL,
-    .logData = NULL,
   };
 
   switch(config->type) {
@@ -87,8 +84,6 @@ int session_init(struct session* session, struct config *config) {
     case TPM_TYPE_DEVICE: {
       TCTI_DEVICE_CONF conf = {
         .device_path = config->device != NULL ? config->device : DEFAULT_DEVICE,
-        .logCallback = NULL,
-        .logData = NULL,
       };
       rc = InitDeviceTcti(tcti_ctx, &size, &conf);
       break;


### PR DESCRIPTION
Upstream has changed the API data structure TCTI_SOCKET_CONF and TCTI_DEVICE_CONF.
"logCallback/logBufferCallback/logData" is deprecated since https://github.com/intel/tpm2-tss/commit/43a0d76bf4e8f50b164a8be89102f1de03d46fa6#diff-9b5d40e51314bbf4fdfc0997a4b58838