### PR TITLE
Require that the libtasn1.pc must be available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     - libdbus-1-dev
     - libglib2.0-dev
     - pandoc
+    - libcurl4-gnutls-dev
 
 install:
     # build tpm2 simulator - needed for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ compiler:
   - clang-3.8
 
 env:
-  - TSS_BRANCH=master TPM2_TOOLS_BRANCH=master
+  - TSS_BRANCH=master TPM2_TOOLS_BRANCH=master TSS_CONFIGURATIONS=--disable-esapi
 
 matrix:
   include:
-    env: TSS_BRANCH=1.x TPM2_TOOLS_BRANCH=3.0.3
+    env: TSS_BRANCH=1.x TPM2_TOOLS_BRANCH=3.0.3 TSS_CONFIGURATIONS=
 
 sudo: required
 dist: trusty
@@ -40,7 +40,7 @@ install:
   - popd
   - git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TSS_BRANCH
   - pushd tpm2-tss
-  - ./bootstrap && ./configure && make -j$(nproc)
+  - ./bootstrap && ./configure ${TSS_CONFIGURATIONS} && make -j$(nproc)
   - sudo make install
   - popd
   - sudo ldconfig /usr/local/lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_check_modules(SAPI REQUIRED sapi)
 pkg_check_modules(TCTI_SOCKET tcti-socket)
 pkg_check_modules(TCTI_DEVICE tcti-device)
 pkg_check_modules(TCTI_TABRMD tcti-tabrmd)
-pkg_check_modules(LIBTASN1 libtasn1)
+pkg_check_modules(LIBTASN1 REQUIRED libtasn1)
 
 if(NOT TCTI_SOCKET_FOUND AND NOT TCTI_DEVICE_FOUND AND NOT TCTI_TABRMD_FOUND)
   message(FATAL_ERROR "At least one connection type must be enabled")


### PR DESCRIPTION
A fatal error would be triggered when libtasn1 was installed on the localhost:
```
$ cmake .
-- Checking for module 'libtasn1'
--   No package 'libtasn1' found
-- Configuring done
-- Generating done
-- Build files have been written to current dir

$ make
Scanning dependencies of target tpm2-pk11
[  9%] Building C object CMakeFiles/tpm2-pk11.dir/src/certificate.c.o
/home/pi/.tpm2/tpm2-pk11/src/certificate.c:30:22: fatal error: libtasn1.h: No such file or directory
 #include <libtasn1.h>
                      ^
compilation terminated.
```
Add REQUIRED into pkg_check_modules to prevent it.