### PR TITLE
Travis CI: Add build dependency on libgcrypt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     - libdbus-1-dev
     - libglib2.0-dev
     - pandoc
+    - libgcrypt20-dev
 
 install:
     # build tpm2 simulator - needed for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     - libglib2.0-dev
     - pandoc
     - libgcrypt20-dev
+    - libcurl4-openssl-dev
 
 install:
     # build tpm2 simulator - needed for testing


### PR DESCRIPTION
Upstream package tpm2-tss now requires libgcrypt20, see:
https://github.com/tpm2-software/tpm2-tss/commit/e829b744f749f9e3922bb4b50a8f371b40a550e7