### PR TITLE
Fix Travis CI package dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     - libdbus-1-dev
     - libglib2.0-dev
     - pandoc
+    - libcurl4-gnutls-dev
 
 install:
     # build tpm2 simulator - needed for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ compiler:
   - clang-3.8
 
 env:
-  - TSS_BRANCH=master TPM2_TOOLS_BRANCH=master
+  - TSS_BRANCH=master TPM2_TOOLS_BRANCH=master TSS_CONFIGURATIONS=--disable-esapi
 
 matrix:
   include:
-    env: TSS_BRANCH=1.x TPM2_TOOLS_BRANCH=3.0.3
+    env: TSS_BRANCH=1.x TPM2_TOOLS_BRANCH=3.0.3 TSS_CONFIGURATIONS=
 
 sudo: required
 dist: trusty
@@ -40,7 +40,7 @@ install:
   - popd
   - git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TSS_BRANCH
   - pushd tpm2-tss
-  - ./bootstrap && ./configure && make -j$(nproc)
+  - ./bootstrap && ./configure ${TSS_CONFIGURATIONS} && make -j$(nproc)
   - sudo make install
   - popd
   - sudo ldconfig /usr/local/lib


### PR DESCRIPTION
This is an replacement of PR #50 .
- Disable ESAPI for tpm2-tss, because: package libgcrypt20-dev and libcurl4-dev conflict to each other on Travis CI, see:
https://github.com/tpm2-software/tpm2-tools/commit/2096ee2f223a3a7afe9c07cdd99cd3de45a01f2f

- libcurl4-dev is required by tpm2-tools