### PR TITLE
Fixup compatible upstream headers

### DIFF
--- a/src/certificate.c
+++ b/src/certificate.c
@@ -25,6 +25,7 @@
 #include "utils.h"
 
 #include <stdio.h>
+#include <stdlib.h> // using malloc(), calloc(), free(), getenv()
 #include <string.h>
 
 #include <libtasn1.h>

--- a/src/objects.c
+++ b/src/objects.c
@@ -25,6 +25,8 @@
 #include "pk11.h"
 
 #include <stdio.h>
+#include <stdlib.h> // using malloc(), calloc(), free()
+#include <string.h> // using memset()
 #include <endian.h>
 #include <limits.h>
 #ifndef PATH_MAX

--- a/src/objects.h
+++ b/src/objects.h
@@ -22,7 +22,7 @@
 #include "config.h"
 #include "object.h"
 
-#include <sapi/tpm20.h>
+#include "tpm20_compat.h"
 
 typedef struct object_list_t {
   pObject object;

--- a/src/pk11.c
+++ b/src/pk11.c
@@ -29,6 +29,7 @@
 #include <sys/mman.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h> // using malloc(), free(), getenv()
 #include <endian.h>
 
 #define SLOT_ID 0x1234

--- a/src/sessions.c
+++ b/src/sessions.c
@@ -17,16 +17,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "tpm20_compat.h"
 #include "sessions.h"
 
 #include <stdlib.h>
 
-#ifdef TCTI_SOCKET_ENABLED
-#include <tcti/tcti_socket.h>
-#endif // TCTI_SOCKET_ENABLED
-#ifdef TCTI_MSSIM_ENABLED
-#include <tcti/tcti_mssim.h>
-#endif // TCTI_MSSIM_ENABLED
 
 #define DEFAULT_DEVICE "/dev/tpm0"
 #define DEFAULT_HOSTNAME "127.0.0.1"
@@ -123,12 +118,8 @@ int session_init(struct session* session, struct config *config) {
   if (session->context == NULL)
     goto cleanup;
 
-  TSS2_ABI_VERSION abi_version = {
-    .tssCreator = TSSWG_INTEROP,
-    .tssFamily = TSS_SAPI_FIRST_FAMILY,
-    .tssLevel = TSS_SAPI_FIRST_LEVEL,
-    .tssVersion = TSS_SAPI_FIRST_VERSION,
-  };
+  TSS2_ABI_VERSION abi_version;
+  guess_tss2_abi_version(&abi_version);
   rc = Tss2_Sys_Initialize(session->context, size, tcti_ctx, &abi_version);
 
   session->objects = object_load(session->context, config);

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -19,6 +19,8 @@
 
 #include "tpm.h"
 
+#include <stdlib.h> // using malloc(), calloc(), free()
+#include <string.h> // using memset(), memcmp(), memcpy()
 #include <endian.h>
 
 const unsigned char oid_sha1[] = {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E, 0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14};

--- a/src/tpm20_compat.c
+++ b/src/tpm20_compat.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of tpm2-pk11.
+ * Copyright (C) 2018 Iwan Timmer
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "tpm20_compat.h"
+
+/** Guess TSS2_ABI_VERSION numbers
+ *
+ * ABI version checking method was changed by upstream developers. Here we are
+ * trying to guess out the hidden version numbers in the master branch of
+ * tpm2-tss. In the future, we may pull those magic version numbers directly
+ * from "Tss2_Sys_Initialize.c" of upstream source tree. See:
+ * https://github.com/tpm2-software/tpm2-tss/pull/864
+ */
+const TSS2_ABI_VERSION guess_tss2_abi_version(TSS2_ABI_VERSION *answer) {
+#ifndef TSSWG_INTEROP
+  const uint32_t TSSWG_INTEROP = 1;
+#endif
+#ifndef TSS_SAPI_FIRST_FAMILY
+  const uint32_t TSS_SAPI_FIRST_FAMILY = 2;
+#endif
+#ifndef TSS_SAPI_FIRST_LEVEL
+  const uint32_t TSS_SAPI_FIRST_LEVEL = 1;
+#endif
+#ifndef TSS_SAPI_FIRST_VERSION
+  const uint32_t TSS_SAPI_FIRST_VERSION = 108;
+#endif
+
+  answer->tssCreator = TSSWG_INTEROP;
+  answer->tssFamily = TSS_SAPI_FIRST_FAMILY;
+  answer->tssLevel = TSS_SAPI_FIRST_LEVEL;
+  answer->tssVersion = TSS_SAPI_FIRST_VERSION;
+
+  return (*answer);
+}

--- a/src/tpm20_compat.h
+++ b/src/tpm20_compat.h
@@ -21,14 +21,25 @@
 
 #include <stdio.h>
 
-#include <sapi/tpm20.h>
+#ifndef TSS_COMPAT
+#  include <tss2/tss2_sys.h>
+#  include <tss2/tss2_tcti.h>
+#  include <tss2/tss2_tcti_device.h>
+#  include <tss2/tss2_tcti_mssim.h>
+#  ifdef TCTI_TABRMD_ENABLED
+#    include <tcti/tss2-tcti-tabrmd.h>
+#  endif /* TCTI_TABRMD_ENABLED */
+#else /* TSS_COMPAT */
+#  include <sapi/tpm20.h>
+#  include <tcti/tcti_device.h>
+#  include <tcti/tcti_socket.h>
+#  ifdef TCTI_TABRMD_ENABLED
+#    include <tcti/tcti-tabrmd.h>
+#  endif /* TCTI_TABRMD_ENABLED */
+#endif /* TSS_COMPAT */
 
-#ifdef TCTI_DEVICE_ENABLED
-#include <tcti/tcti_device.h>
-#endif // TCTI_DEVICE_ENABLED
-#ifdef TCTI_TABRMD_ENABLED
-#include <tcti/tcti-tabrmd.h>
-#endif // TCTI_TABRMD_ENABLED
+/** Compatible TSS2_ABI_VERSION guessing-out method */
+const TSS2_ABI_VERSION guess_tss2_abi_version(TSS2_ABI_VERSION *answer);
 
 #ifndef TSS_COMPAT
 


### PR DESCRIPTION
This is an attempt to fix up the broken upstream compatible layer. Following up the previous PR https://github.com/irtimmer/tpm2-pk11/pull/62

Fixes #58
Fixes #60 