### PR TITLE
Prevent gcc warnings on memset()

### DIFF
--- a/src/sessions.c
+++ b/src/sessions.c
@@ -28,6 +28,7 @@
 #include "sessions.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 
 #define DEFAULT_DEVICE "/dev/tpm0"


### PR DESCRIPTION
Adding `#include <string.h>` would prevent the following gcc warning:
```
[ 78%] Building C object CMakeFiles/tpm2-pk11.dir/src/sessions.c.o
/home/travis/build/liuqun/tpm2-pk11/src/sessions.c: In function ‘session_init’:
/home/travis/build/liuqun/tpm2-pk11/src/sessions.c:40:3: warning: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
   memset(session, 0, sizeof(struct session));
   ^
/home/travis/build/liuqun/tpm2-pk11/src/sessions.c:40:3: warning: incompatible implicit declaration of built-in function ‘memset’ [enabled by default]
```