### PR TITLE
Fix tpm_set_session_password to compile with recent tpm2-tss and tpm2-abrmd 2.0 versions

### DIFF
--- a/src/tpm.c
+++ b/src/tpm.c
@@ -36,8 +36,8 @@ const unsigned char oid_sha512[] = {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x
 
 static void tpm_set_session_password(TSS2L_SYS_AUTH_COMMAND *sessions_data, char *password) {
   TPMS_AUTH_COMMAND *cmd = sessions_data->cmdAuths[0];
-  strncat(cmd->hmac.t.buffer, password, sizeof(TPMU_HA));
-  cmd->hmac.t.size = strlen(password) >= sizeof(TPMU_HA) ? 0 : strlen(password);
+  strncat(cmd->hmac.TSS_COMPAT_TMPB(buffer), password, sizeof(TPMU_HA));
+  cmd->hmac.TSS_COMPAT_TMPB(size) = strlen(password) >= sizeof(TPMU_HA) ? 0 : strlen(password);
 }
 
 TPM2_RC tpm_readpublic(TSS2_SYS_CONTEXT *context, TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public, TPM2B_NAME *name) {

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -35,7 +35,7 @@ const unsigned char oid_sha384[] = {0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x
 const unsigned char oid_sha512[] = {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,0x00, 0x04, 0x40};
 
 static void tpm_set_session_password(TSS2L_SYS_AUTH_COMMAND *sessions_data, char *password) {
-  TPMS_AUTH_COMMAND *cmd = sessions_data->cmdAuths[0];
+  TPMS_AUTH_COMMAND *cmd = TSS_COMPAT_AUTHS(sessions_data);
   strncat(cmd->hmac.TSS_COMPAT_TMPB(buffer), password, sizeof(TPMU_HA));
   cmd->hmac.TSS_COMPAT_TMPB(size) = strlen(password) >= sizeof(TPMU_HA) ? 0 : strlen(password);
 }

--- a/src/tpm20_compat.h
+++ b/src/tpm20_compat.h
@@ -36,7 +36,7 @@
 #include <tss2/tss2_tcti_mssim.h>
 #endif /* TCTI_SOCKET_ENABLED */
 #ifdef TCTI_MSSIM_ENABLED
-#include <tcti/tss2-tcti-tabrmd.h>
+#include <tss2/tss2-tcti-tabrmd.h>
 #endif /* TCTI_TABRMD_ENABLED */
 #else /* TSS_COMPAT */
 #include <sapi/tpm20.h>

--- a/src/tpm20_compat.h
+++ b/src/tpm20_compat.h
@@ -70,6 +70,8 @@ typedef char* TSS_COMPAT_TCTI_DEVICE_CONF;
 
 #define TSS_COMPAT_DEVICE_CONF(x, y) x = y
 
+#define TSS_COMPAT_AUTHS(x) &x->auths[0]
+
 #else /* TSS_COMPAT */
 
 #define Tss2_Tcti_Device_Init(x, y, z) InitDeviceTcti(x, y, &z)
@@ -132,6 +134,8 @@ typedef char* TSS_COMPAT_TCTI_DEVICE_CONF;
 #define TSS_COMPAT_TMPB(x) t.x
 
 #define TSS_COMPAT_DEVICE_CONF(x, y) x = (TCTI_DEVICE_CONF) { .device_path = y }
+
+#define TSS_COMPAT_AUTHS(x) x->cmdAuths[0]
 
 typedef TCTI_DEVICE_CONF TSS_COMPAT_TCTI_DEVICE_CONF;
 


### PR DESCRIPTION
Currently this project does not compile with the released versions of [tpm2-tss](https://github.com/tpm2-software/tpm2-tss) 2.0 and [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd) 2.0, instead the older versions 1.4 and 1.3, respectively: the problem is that the already existing [compatibility layer](https://github.com/irtimmer/tpm2-pk11/blob/master/src/tpm20_compat.h) for the differences between these versions has not been applied to the `tpm_set_session_password` function.

Namely, the following three changes affect the `tpm_set_session_password`:
- `tss2-tcti-tabrmd.h` has been moved from ` tcti`  to ` tss2`  folder in https://github.com/tpm2-software/tpm2-abrmd/pull/452.
- The `TPM2B_AUTH` type has been changed in https://github.com/tpm2-software/tpm2-tss/pull/600 according to the TPM2 specification to remove `t`.
- The `TSS2L_SYS_AUTH_COMMAND` type has been changed according to the TPM2 specification in https://github.com/tpm2-software/tpm2-tss/pull/634: `cmdAuths` has been renamed to `auths` and is not a pointer any more.

This pull request makes these changes in three separate commits in the order listed, while retaining compatibility with tpm-tss and tpm2-abrmd 1.X. I confirm that the code compiles with both 1.X and 2.X, however some feedback would be greatly appreciated (especially for the third commit) as I do not know how to actually test the correct behaviour of the modified `tpm_set_session_password` function.