### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     # build tpm2-tools - needed for testing
   - git clone https://github.com/tpm2-software/tpm2-tools.git --branch $TPM2_TOOLS_BRANCH
   - pushd tpm2-tools
-  - ./bootstrap && ./configure --disable-dlclose && make -j$(nproc) && sudo make install
+  - ./bootstrap && TSS2_SYS_CFLAGS='-Wno-missing-field-initializers' ./configure --disable-dlclose && make -j$(nproc) && sudo make install
   - popd
     # setup travis environment for testing.
   - mkdir -p ~/.ssh

--- a/test/bat/test_util.bash
+++ b/test/bat/test_util.bash
@@ -1,12 +1,12 @@
 create_key() {
-    tpm2_createprimary -a o -g sha256 -G rsa -C po.ctx
-    tpm2_create -c po.ctx -g sha256 -G rsa -u key.pub -r key.priv
-    tpm2_load -c po.ctx -u key.pub -r key.priv -C obj.ctx
-    tpm2_evictcontrol -a o -c obj.ctx -H 0x81010010
+    tpm2_createprimary -a o -g sha256 -G rsa -o po.ctx
+    tpm2_create -C po.ctx -g sha256 -G rsa -u key.pub -r key.priv
+    tpm2_load -C po.ctx -u key.pub -r key.priv -o obj.ctx
+    tpm2_evictcontrol -a o -c obj.ctx -p 0x81010010
 }
 
 delete_key() {
-    tpm2_evictcontrol -a o -H 0x81010010 -p 0x81010010
+    tpm2_evictcontrol -a o -c 0x81010010
     rm key.pub
     rm key.priv
 }


### PR DESCRIPTION
Currently, there are two problems with the continuous integration that are fixed by this pull request:
- On the [tpm2-tools](https://www.github.com/tpm2-software/tpm2-tools) master branch, some option names have changed. In the tests for tpm2-pk11, the old option names are still used, causing failed checks. The first commit updates the option names.
- tpm2-tools does not compile with clang 3.8 due to a "missing field initializer" warning that is treated as an error by `-Werror`. The second commit disables this warning for the tpm2-tools build. A better solution would be to update clang to a more recent version that does not show this warning any more, but that seems to be more difficult with Travis.